### PR TITLE
Statically link C libraries

### DIFF
--- a/.goreleaser.ubuntu-latest.yml
+++ b/.goreleaser.ubuntu-latest.yml
@@ -24,6 +24,7 @@ builds:
         - hidraw
       env:
         - CGO_ENABLED=1
+        - CGO_LDFLAGS=-static
 archives:
   - format: tar.gz
     wrap_in_directory: false


### PR DESCRIPTION
Statically link C libraries now that CGO_ENABLED is set to 1. This eliminates dependencies on glibc version (#1010).